### PR TITLE
Fix league-extract silent failure on preseason payloads

### DIFF
--- a/espn_api_extractor/controllers/league_controller.py
+++ b/espn_api_extractor/controllers/league_controller.py
@@ -1,3 +1,4 @@
+import traceback
 from typing import Any, Dict, Optional
 
 from espn_api_extractor.handlers.league_handler import LeagueHandler
@@ -27,6 +28,7 @@ class LeagueController:
             league_data: Optional[dict] = self.league_handler.fetch()
             return {"league": league_data, "failures": []}
         except Exception as e:
-            error_msg = f"League extraction failed: {str(e)}"
+            error_msg = f"League extraction failed: {type(e).__name__}: {e!r}"
             self.logger.error(error_msg)
+            self.logger.error(traceback.format_exc())
             return {"league": None, "failures": [error_msg]}

--- a/espn_api_extractor/handlers/league_handler.py
+++ b/espn_api_extractor/handlers/league_handler.py
@@ -76,7 +76,8 @@ class LeagueHandler:
 
     def _filter_acquisition_settings(self, settings: dict) -> dict:
         acquisition_settings = settings.get("acquisitionSettings")
-        assert isinstance(acquisition_settings, dict)
+        if not isinstance(acquisition_settings, dict):
+            return settings
 
         updated = dict(settings)
         updated["acquisitionSettings"] = {
@@ -88,7 +89,8 @@ class LeagueHandler:
 
     def _filter_scoring_settings(self, settings: dict) -> dict:
         scoring_settings = settings.get("scoringSettings")
-        assert isinstance(scoring_settings, dict)
+        if not isinstance(scoring_settings, dict):
+            return settings
 
         scoring_settings = dict(scoring_settings)
         scoring_items = scoring_settings.pop("scoringItems", None)
@@ -118,7 +120,8 @@ class LeagueHandler:
 
     def _filter_status(self, data: dict) -> dict:
         status = data.get("status")
-        assert isinstance(status, dict)
+        if not isinstance(status, dict):
+            return data
 
         updated = dict(data)
         updated_status = dict(status)
@@ -195,7 +198,8 @@ class LeagueHandler:
         }
 
     def _format_record(self, cumulative_score: Optional[dict]) -> str:
-        assert isinstance(cumulative_score, dict)
+        if not isinstance(cumulative_score, dict):
+            return "0-0-0"
         wins = cumulative_score.get("wins", 0)
         losses = cumulative_score.get("losses", 0)
         ties = cumulative_score.get("ties", 0)

--- a/espn_api_extractor/runners/league_extract_runner.py
+++ b/espn_api_extractor/runners/league_extract_runner.py
@@ -28,12 +28,14 @@ class LeagueExtractRunner:
             league_data = results["league"]
             failures = results["failures"]
 
-            if league_data is not None:
-                self._save_extraction_results(league_data, failures)
+            if league_data is None:
+                detail = "; ".join(failures) if failures else "unknown error"
+                raise RuntimeError(f"League extraction produced no data: {detail}")
 
+            self._save_extraction_results(league_data, failures)
             return league_data
         except Exception as e:
-            self.logger.error(f"League extraction failed: {e}")
+            self.logger.error(f"League extraction failed: {type(e).__name__}: {e!r}")
             raise
 
     def _save_extraction_results(

--- a/tests/controllers/test_league_controller.py
+++ b/tests/controllers/test_league_controller.py
@@ -71,5 +71,8 @@ def test_league_controller_execute_failure(monkeypatch):
     logger.info.assert_called_once_with(
         "Fetching league data for league 10998 year 2025"
     )
-    logger.error.assert_called_once_with("League extraction failed: boom")
-    assert result == {"league": None, "failures": ["League extraction failed: boom"]}
+    expected_msg = "League extraction failed: RuntimeError: RuntimeError('boom')"
+    assert logger.error.call_count == 2
+    assert logger.error.call_args_list[0].args == (expected_msg,)
+    assert "Traceback" in logger.error.call_args_list[1].args[0]
+    assert result == {"league": None, "failures": [expected_msg]}

--- a/tests/runners/test_league_extract_runner.py
+++ b/tests/runners/test_league_extract_runner.py
@@ -36,7 +36,7 @@ def test_league_extract_runner_saves_when_data_present(monkeypatch, tmp_path):
     assert result == league_data
 
 
-def test_league_extract_runner_skips_save_when_no_data(monkeypatch, tmp_path):
+def test_league_extract_runner_raises_when_no_data(monkeypatch, tmp_path):
     args = SimpleNamespace(
         league_id=10998,
         year=2025,
@@ -54,11 +54,11 @@ def test_league_extract_runner_skips_save_when_no_data(monkeypatch, tmp_path):
     runner = LeagueExtractRunner(args)
     monkeypatch.setattr(runner, "_save_extraction_results", MagicMock())
 
-    result = asyncio.run(runner.run())
+    with pytest.raises(RuntimeError, match="League extraction produced no data: no"):
+        asyncio.run(runner.run())
 
     controller.execute.assert_awaited_once_with()
     runner._save_extraction_results.assert_not_called()
-    assert result is None
 
 
 def test_league_extract_runner_save_results_writes_files(tmp_path):


### PR DESCRIPTION
## Summary
- Replace bare `assert isinstance(...)` guards in `LeagueHandler` with graceful fallbacks (`_format_record`, `_filter_acquisition_settings`, `_filter_scoring_settings`, `_filter_status`)
- Controller now logs exception type, `repr(e)`, and full traceback
- Runner raises `RuntimeError` when the controller returns no data, so failures surface as non-zero exit codes
- Update tests to match the new error format and raising behavior

## Why
Running `espn league-extract --year 2026` was silently failing: the CLI printed `League extraction failed:` (nothing after the colon) and exited 0, no league file was written, and the MTBL_ET orchestrator reported "completed successfully."

Root cause: 2026 preseason matchups arrive without a `cumulativeScore` field on many entries. `_format_record` did `assert isinstance(cumulative_score, dict)`, which raised an `AssertionError` with an empty message. The controller caught it and formatted `f"League extraction failed: {str(e)}"` — producing an empty message — then returned `{"league": None}`. The runner's `if league_data is not None: save(...)` branch was skipped, and it returned `None` cleanly. The whole pipeline looked fine.

Verified with a direct `curl` against `https://lm-api-reads.fantasy.espn.com/apis/v3/games/flb/seasons/2026/segments/0/leagues/10998?view=mTeam&view=mRoster&view=mMatchupScore&view=mSettings&view=mStandings` — HTTP 200, 1.7MB response, no auth needed. The failure was purely in post-fetch filtering.

## Test plan
- [x] `pytest tests/` — 143 passed, 1 skipped
- [x] `espn league-extract --year 2026` writes `espn_league_10998_2026_*.json` and exits 0
- [x] Full `mtbl-et` pipeline runs end-to-end producing a 2026 league file
- [ ] `espn league-extract --year 2025` still works (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)