### PR TITLE
Replace tqdm with rich.progress for hydration progress bars

### DIFF
--- a/espn_api_extractor/requests/core_requests.py
+++ b/espn_api_extractor/requests/core_requests.py
@@ -308,10 +308,8 @@ class EspnCoreRequests:
             )
 
         total_batches = (total_players + batch_size - 1) // batch_size
+        hydration_start = time.perf_counter()
 
-        # Rich's Progress manages multiple concurrent tasks in one rendered
-        # block — replaces the nested tqdm bars (position=0 overall, position=1
-        # per-batch with leave=False).
         with Progress(
             TextColumn("[progress.description]{task.description}"),
             BarColumn(),
@@ -319,7 +317,7 @@ class EspnCoreRequests:
             TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
             TimeElapsedColumn(),
             TimeRemainingColumn(),
-            transient=False,
+            transient=True,
         ) as progress:
             overall_task = progress.add_task(
                 "Total progress", total=total_players
@@ -330,8 +328,6 @@ class EspnCoreRequests:
                 batch_size_actual = len(batch)
                 batch_num = i // batch_size + 1
 
-                # Per-batch task removed after completion (rich equivalent of
-                # tqdm's ``leave=False``).
                 batch_task = progress.add_task(
                     f"Batch {batch_num}/{total_batches}",
                     total=batch_size_actual,
@@ -371,10 +367,11 @@ class EspnCoreRequests:
                 finally:
                     progress.remove_task(batch_task)
 
-        # Log summary of hydration results
+        hydration_elapsed = time.perf_counter() - hydration_start
+
         with self.logger_lock:
             self.logger.logging.info(
-                f"Successfully hydrated {len(hydrated_players)} players"
+                f"Successfully hydrated {len(hydrated_players)} players in {hydration_elapsed:.1f}s"
             )
             if failed_players:
                 self.logger.logging.warning(

--- a/espn_api_extractor/requests/core_requests.py
+++ b/espn_api_extractor/requests/core_requests.py
@@ -6,7 +6,14 @@ from threading import Lock
 
 import requests
 from requests.cookies import RequestsCookieJar
-from tqdm import tqdm
+from rich.progress import (
+    BarColumn,
+    MofNCompleteColumn,
+    Progress,
+    TextColumn,
+    TimeElapsedColumn,
+    TimeRemainingColumn,
+)
 from typing_extensions import Any, Dict, List, Optional, Tuple
 
 from espn_api_extractor.baseball.player import Player
@@ -300,26 +307,37 @@ class EspnCoreRequests:
                 f"Starting multi-threaded hydration of {total_players} players with {self.max_workers} workers"
             )
 
-        # Create an overall progress bar
-        with tqdm(
-            total=total_players, desc="Total progress", unit="player", position=0
-        ) as overall_progress:
-            # Process players in batches to provide progress feedback
+        total_batches = (total_players + batch_size - 1) // batch_size
+
+        # Rich's Progress manages multiple concurrent tasks in one rendered
+        # block — replaces the nested tqdm bars (position=0 overall, position=1
+        # per-batch with leave=False).
+        with Progress(
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            MofNCompleteColumn(),
+            TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+            TimeElapsedColumn(),
+            TimeRemainingColumn(),
+            transient=False,
+        ) as progress:
+            overall_task = progress.add_task(
+                "Total progress", total=total_players
+            )
+
             for i in range(0, total_players, batch_size):
                 batch = players[i : i + batch_size]
                 batch_size_actual = len(batch)
+                batch_num = i // batch_size + 1
 
-                # Create progress bar for current batch (position=1 places it below the overall progress bar)
-                with tqdm(
+                # Per-batch task removed after completion (rich equivalent of
+                # tqdm's ``leave=False``).
+                batch_task = progress.add_task(
+                    f"Batch {batch_num}/{total_batches}",
                     total=batch_size_actual,
-                    desc=f"Batch {i // batch_size + 1}/{(total_players + batch_size - 1) // batch_size}",
-                    unit="player",
-                    position=1,
-                    leave=False,
-                ) as batch_progress:
-                    # Use thread pool to process players in parallel
+                )
+                try:
                     with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
-                        # Submit all player hydration tasks to thread pool
                         futures_to_players = {
                             executor.submit(
                                 self._hydrate_player_worker, player, include_stats
@@ -327,14 +345,11 @@ class EspnCoreRequests:
                             for player in batch
                         }
 
-                        # Process results as they complete
                         for future in as_completed(futures_to_players):
                             player = futures_to_players[future]
                             try:
-                                # Get result from the future
                                 hydrated_player, success = future.result()
 
-                                # Update collections based on success
                                 if success:
                                     hydrated_players.append(hydrated_player)
                                 else:
@@ -345,16 +360,16 @@ class EspnCoreRequests:
                                             f"{player.display_name if hasattr(player, 'display_name') else 'Unknown'}"
                                         )
                             except Exception as exc:
-                                # Handle any uncaught exceptions from the thread
                                 with self.logger_lock:
                                     self.logger.logging.error(
                                         f"Player {player.id} generated an exception: {exc}"
                                     )
                                 failed_players.append(player)
 
-                            # Update both progress bars
-                            batch_progress.update(1)
-                            overall_progress.update(1)
+                            progress.advance(batch_task)
+                            progress.advance(overall_task)
+                finally:
+                    progress.remove_task(batch_task)
 
         # Log summary of hydration results
         with self.logger_lock:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.13"
 dependencies = [
     "requests>=2.32.3,<3.0.0",
     "pydantic>=2.11.4,<3.0.0",
-    "tqdm>=4.67.1,<5.0.0",
+    "rich>=13.7.0,<15.0.0",
 ]
 
 [project.optional-dependencies]
@@ -18,7 +18,6 @@ dev = [
     "pytest-cov>=6.1.1",
     "mypy>=1.15.0",
     "types-requests>=2.32.0.1",
-    "types-tqdm>=4.66.0.20240106",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -138,7 +138,7 @@ source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
     { name = "requests" },
-    { name = "tqdm" },
+    { name = "rich" },
 ]
 
 [package.optional-dependencies]
@@ -148,7 +148,6 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "types-requests" },
-    { name = "types-tqdm" },
 ]
 
 [package.metadata]
@@ -159,9 +158,8 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.5" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.1.1" },
     { name = "requests", specifier = ">=2.32.3,<3.0.0" },
-    { name = "tqdm", specifier = ">=4.67.1,<5.0.0" },
+    { name = "rich", specifier = ">=13.7.0,<15.0.0" },
     { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.32.0.1" },
-    { name = "types-tqdm", marker = "extra == 'dev'", specifier = ">=4.66.0.20240106" },
 ]
 provides-extras = ["dev"]
 
@@ -231,6 +229,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/7f/12a73ff17bca4351e73d585dd9ebf46723c4a8622c4af7fe11a2e2d011ff/librt-0.7.3-cp314-cp314t-win32.whl", hash = "sha256:d09f677693328503c9e492e33e9601464297c01f9ebd966ea8fc5308f3069bfd", size = 45586, upload-time = "2025-12-06T19:04:29.116Z" },
     { url = "https://files.pythonhosted.org/packages/e2/df/8decd032ac9b995e4f5606cde783711a71094128d88d97a52e397daf2c89/librt-0.7.3-cp314-cp314t-win_amd64.whl", hash = "sha256:25711f364c64cab2c910a0247e90b51421e45dbc8910ceeb4eac97a9e132fc6f", size = 53002, upload-time = "2025-12-06T19:04:30.173Z" },
     { url = "https://files.pythonhosted.org/packages/de/0c/6605b6199de8178afe7efc77ca1d8e6db00453bc1d3349d27605c0f42104/librt-0.7.3-cp314-cp314t-win_arm64.whl", hash = "sha256:a9f9b661f82693eb56beb0605156c7fca57f535704ab91837405913417d6990b", size = 45647, upload-time = "2025-12-06T19:04:31.302Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -432,15 +451,16 @@ wheels = [
 ]
 
 [[package]]
-name = "tqdm"
-version = "4.67.1"
+name = "rich"
+version = "14.3.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "markdown-it-py" },
+    { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/67/cae617f1351490c25a4b8ac3b8b63a4dda609295d8222bad12242dfdc629/rich-14.3.4.tar.gz", hash = "sha256:817e02727f2b25b40ef56f5aa2217f400c8489f79ca8f46ea2b70dd5e14558a9", size = 230524, upload-time = "2026-04-11T02:57:45.419Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/76/6d163cfac87b632216f71879e6b2cf17163f773ff59c00b5ff4900a80fa3/rich-14.3.4-py3-none-any.whl", hash = "sha256:07e7adb4690f68864777b1450859253bed81a99a31ac321ac1817b2313558952", size = 310480, upload-time = "2026-04-11T02:57:47.484Z" },
 ]
 
 [[package]]
@@ -453,18 +473,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/36/27/489922f4505975b11de2b5ad07b4fe1dca0bca9be81a703f26c5f3acfce5/types_requests-2.32.4.20250913.tar.gz", hash = "sha256:abd6d4f9ce3a9383f269775a9835a4c24e5cd6b9f647d64f88aa4613c33def5d", size = 23113, upload-time = "2025-09-13T02:40:02.309Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/20/9a227ea57c1285986c4cf78400d0a91615d25b24e257fd9e2969606bdfae/types_requests-2.32.4.20250913-py3-none-any.whl", hash = "sha256:78c9c1fffebbe0fa487a418e0fa5252017e9c60d1a2da394077f1780f655d7e1", size = 20658, upload-time = "2025-09-13T02:40:01.115Z" },
-]
-
-[[package]]
-name = "types-tqdm"
-version = "4.67.0.20250809"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "types-requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/d0/cf498fc630d9fdaf2428b93e60b0e67b08008fec22b78716b8323cf644dc/types_tqdm-4.67.0.20250809.tar.gz", hash = "sha256:02bf7ab91256080b9c4c63f9f11b519c27baaf52718e5fdab9e9606da168d500", size = 17200, upload-time = "2025-08-09T03:17:43.489Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/13/3ff0781445d7c12730befce0fddbbc7a76e56eb0e7029446f2853238360a/types_tqdm-4.67.0.20250809-py3-none-any.whl", hash = "sha256:1a73053b31fcabf3c1f3e2a9d5ecdba0f301bde47a418cd0e0bdf774827c5c57", size = 24020, upload-time = "2025-08-09T03:17:42.453Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Swap the two nested `tqdm` bars in `EspnCoreRequests.hydrate_players` for a single `rich.progress.Progress` block with two tasks (overall + per-batch).
- Use `progress.remove_task(batch_task)` inside `finally` to mirror tqdm's `leave=False` transient batch bar behavior.
- Drop `tqdm` + `types-tqdm` from `pyproject.toml`, add `rich>=13.7.0,<15.0.0`.

## Notable behavior
- Both bars now render in the same Live block, so terminal redraw is clean (no `position=0/1` workarounds).
- Bonus columns: per-task percentage, elapsed time, and ETA come for free.
- Threaded `progress.advance()` calls are safe — `rich.Progress` serializes internal updates.

## Test plan
- [x] `uv sync --extra dev` succeeds with the new dep set
- [x] `uv run pytest -q` — 143 passed, 1 skipped
- [x] `uv run mypy espn_api_extractor` — clean
- [x] Smoke test rendered nested progress bars in a TTY

🤖 Generated with [Claude Code](https://claude.com/claude-code)