### PR TITLE
Aggregate 404 logging + CLI default updates

### DIFF
--- a/espn_api_extractor/__main__.py
+++ b/espn_api_extractor/__main__.py
@@ -13,7 +13,7 @@ def create_player_parser(subparsers):
     )
 
     player_parser.add_argument(
-        "--year", type=int, default=2025, help="League year (default: 2025)"
+        "--year", type=int, default=2026, help="League year (default: 2026)"
     )
     player_parser.add_argument(
         "--league-id",
@@ -46,8 +46,12 @@ def create_player_parser(subparsers):
     )
     player_parser.add_argument(
         "--force-full-extraction",
-        action="store_true",
-        help="Force full ESPN extraction, bypassing GraphQL optimization (default: False)",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Force full ESPN extraction, bypassing GraphQL optimization "
+            "(default: True; pass --no-force-full-extraction to disable)"
+        ),
     )
     player_parser.add_argument(
         "--graphql-config",
@@ -71,7 +75,7 @@ def create_league_parser(subparsers):
     )
 
     league_parser.add_argument(
-        "--year", type=int, default=2025, help="League year (default: 2025)"
+        "--year", type=int, default=2026, help="League year (default: 2026)"
     )
     league_parser.add_argument(
         "--league_id",

--- a/espn_api_extractor/requests/core_requests.py
+++ b/espn_api_extractor/requests/core_requests.py
@@ -52,6 +52,12 @@ class EspnCoreRequests:
         )
         self.session.cookies = RequestsCookieJar()
 
+        # In-memory store of players that returned 404 during hydration.
+        # Populated by _get_player_data / _fetch_player_stats and reported
+        # in aggregate at the end of hydrate_players to avoid interrupting
+        # the rich progress bar with per-request 404 log lines.
+        self.not_found_players: List[Dict[str, Any]] = []
+
     def _check_request_status(
         self,
         status: int,
@@ -66,8 +72,9 @@ class EspnCoreRequests:
         # Use thread-safe logging
         with self.logger_lock:
             if status == 404:
-                pass
-                # self.logger.logging.warning(f"Endpoint not found: {extend}")
+                # 404s are tracked separately via not_found_players and
+                # reported in aggregate at the end of hydrate_players.
+                return
             elif status == 429:
                 self.logger.logging.warning("Rate limit exceeded")
             elif status == 500:
@@ -92,7 +99,11 @@ class EspnCoreRequests:
         return r.json()
 
     def _get_player_data(
-        self, player_id: int, params: dict = {}, max_retries: int = 3
+        self,
+        player_id: int,
+        params: dict = {},
+        max_retries: int = 3,
+        player: Optional[Player] = None,
     ) -> Optional[Dict[str, Any]]:
         """
         Get player data with retry mechanism.
@@ -100,6 +111,8 @@ class EspnCoreRequests:
         Thread-safe implementation.
 
         Note: 404 errors are not retried since they indicate the player ID doesn't exist.
+        When `player` is provided, 404 hits are recorded to ``self.not_found_players``
+        (instead of logged inline) so the rich progress bar isn't interrupted.
         """
         endpoint = self.sport_endpoint + f"/athletes/{player_id}"
         retries = 0
@@ -126,23 +139,24 @@ class EspnCoreRequests:
                                 response=r.json(),
                             )
                     return r.json()
-                else:
-                    # Log the error status using existing method
-                    self._check_request_status(
-                        r.status_code, extend=endpoint, params=params
-                    )
-                    with self.logger_lock:
-                        self.logger.logging.warning(
-                            f"Failed to fetch player {player_id} (attempt {retries + 1}/{max_retries}): HTTP {r.status_code}"
-                        )
 
-                    # Don't retry 404 errors - player ID doesn't exist
-                    if r.status_code == 404:
-                        with self.logger_lock:
-                            self.logger.logging.warning(
-                                f"Player ID {player_id} not found (404) - skipping retries"
-                            )
-                        return None
+                # Don't retry 404 errors - player ID doesn't exist.
+                # Record to in-memory store and skip inline logging so the
+                # progress bar isn't interrupted; reported at end of run.
+                if r.status_code == 404:
+                    self._record_not_found(
+                        player_id=player_id, player=player, kind="bio"
+                    )
+                    return None
+
+                # Log non-404 errors normally
+                self._check_request_status(
+                    r.status_code, extend=endpoint, params=params
+                )
+                with self.logger_lock:
+                    self.logger.logging.warning(
+                        f"Failed to fetch player {player_id} (attempt {retries + 1}/{max_retries}): HTTP {r.status_code}"
+                    )
 
             except Exception as e:
                 # Handle connection errors, timeouts, etc.
@@ -165,7 +179,11 @@ class EspnCoreRequests:
         return None
 
     def _fetch_player_stats(
-        self, player_id: int, params: dict = {}, max_retries: int = 3
+        self,
+        player_id: int,
+        params: dict = {},
+        max_retries: int = 3,
+        player: Optional[Player] = None,
     ) -> Optional[Dict[str, Any]]:
         """
         Get player statistics with retry mechanism.
@@ -173,6 +191,8 @@ class EspnCoreRequests:
         Thread-safe implementation.
 
         Note: 404 errors are not retried since they indicate the player ID doesn't exist.
+        When `player` is provided, 404 hits are recorded to ``self.not_found_players``
+        (instead of logged inline) so the rich progress bar isn't interrupted.
         """
         current_year = datetime.now().year
         season_type = STAT_SEASON_TYPE  # 2 for regular season
@@ -203,24 +223,18 @@ class EspnCoreRequests:
                                 response=r.json(),
                             )
                     return r.json()
-                else:
-                    # Log the error status using existing method
-                    self._check_request_status(
-                        r.status_code, extend=endpoint, params=params
-                    )
-                    with self.logger_lock:
-                        pass
-                        # self.logger.logging.warning(
-                        #     f"Failed to fetch statistics for player {player_id} (attempt {retries + 1}/{max_retries}): HTTP {r.status_code}"
-                        # )
 
-                    # Don't retry 404 errors - player ID doesn't exist
-                    if r.status_code == 404:
-                        with self.logger_lock:
-                            self.logger.logging.warning(
-                                f"Statistics for player ID {player_id} not found (404) - skipping retries"
-                            )
-                        return None
+                # 404: record silently, don't retry.
+                if r.status_code == 404:
+                    self._record_not_found(
+                        player_id=player_id, player=player, kind="stats"
+                    )
+                    return None
+
+                # Non-404: log via shared status handler and continue retrying.
+                self._check_request_status(
+                    r.status_code, extend=endpoint, params=params
+                )
 
             except Exception as e:
                 # Handle connection errors, timeouts, etc.
@@ -242,6 +256,26 @@ class EspnCoreRequests:
             )
         return None
 
+    def _record_not_found(
+        self, player_id: int, player: Optional[Player], kind: str
+    ) -> None:
+        """Record a 404 hit for later aggregated reporting.
+
+        Thread-safe; writes through ``logger_lock`` to keep the in-memory
+        list consistent across worker threads.
+        """
+        name = getattr(player, "name", None) if player is not None else None
+        team = getattr(player, "pro_team", None) if player is not None else None
+        with self.logger_lock:
+            self.not_found_players.append(
+                {
+                    "id": player_id,
+                    "name": name or "Unknown",
+                    "team": team or "Unknown",
+                    "kind": kind,
+                }
+            )
+
     def _hydrate_player_with_bio(self, player: Player) -> Tuple[Player, bool]:
         """
         Hydrate a player with biographical data from API.
@@ -250,7 +284,7 @@ class EspnCoreRequests:
         """
         assert player.id is not None, "Player ID is required"
 
-        data = self._get_player_data(player.id)
+        data = self._get_player_data(player.id, player=player)
         if data is None:
             return player, False
 
@@ -301,6 +335,10 @@ class EspnCoreRequests:
         failed_players: List[Player] = []
         total_players = len(players)
 
+        # Reset 404 store for this hydration cycle so the aggregated summary
+        # at the end reflects only the current run.
+        self.not_found_players = []
+
         # Log start of multi-threaded hydration
         with self.logger_lock:
             self.logger.logging.info(
@@ -349,12 +387,10 @@ class EspnCoreRequests:
                                 if success:
                                     hydrated_players.append(hydrated_player)
                                 else:
+                                    # Per-player failure logs would interrupt the
+                                    # rich progress bar; the end-of-run summary
+                                    # below reports failures in aggregate.
                                     failed_players.append(hydrated_player)
-                                    with self.logger_lock:
-                                        self.logger.logging.warning(
-                                            f"Failed to hydrate player: {player.id} - "
-                                            f"{player.display_name if hasattr(player, 'display_name') else 'Unknown'}"
-                                        )
                             except Exception as exc:
                                 with self.logger_lock:
                                     self.logger.logging.error(
@@ -373,6 +409,19 @@ class EspnCoreRequests:
             self.logger.logging.info(
                 f"Successfully hydrated {len(hydrated_players)} players in {hydration_elapsed:.1f}s"
             )
+
+            # Aggregate report for 404s collected during this run. Printed
+            # after the progress bar exits so it doesn't get clobbered.
+            if self.not_found_players:
+                self.logger.logging.warning(
+                    f"Skipped {len(self.not_found_players)} player(s) returning 404:"
+                )
+                for entry in self.not_found_players:
+                    self.logger.logging.warning(
+                        f"  [404 {entry['kind']}] ID={entry['id']}, "
+                        f"Name={entry['name']}, Team={entry['team']}"
+                    )
+
             if failed_players:
                 self.logger.logging.warning(
                     f"Failed to hydrate {len(failed_players)} players"
@@ -382,11 +431,13 @@ class EspnCoreRequests:
                 ):  # Log first 10 failed players
                     player_name = (
                         player.display_name
-                        if hasattr(player, "display_name")
-                        else "Unknown"
+                        if hasattr(player, "display_name") and player.display_name
+                        else getattr(player, "name", None) or "Unknown"
                     )
+                    player_team = getattr(player, "pro_team", None) or "Unknown"
                     self.logger.logging.warning(
-                        f"  Failed player {i + 1}: ID={player.id}, Name={player_name}"
+                        f"  Failed player {i + 1}: ID={player.id}, "
+                        f"Name={player_name}, Team={player_team}"
                     )
                 if len(failed_players) > 10:
                     self.logger.logging.warning(

--- a/espn_api_extractor/requests/core_requests.py
+++ b/espn_api_extractor/requests/core_requests.py
@@ -6,6 +6,8 @@ from threading import Lock
 
 import requests
 from requests.cookies import RequestsCookieJar
+from rich.console import Group
+from rich.live import Live
 from rich.progress import (
     BarColumn,
     MofNCompleteColumn,
@@ -348,16 +350,22 @@ class EspnCoreRequests:
         total_batches = (total_players + batch_size - 1) // batch_size
         hydration_start = time.perf_counter()
 
-        with Progress(
+        # Two separate Progress instances grouped in a Live render so batch
+        # progress stays above the overall total bar regardless of when each
+        # task was added.
+        progress_columns = (
             TextColumn("[progress.description]{task.description}"),
             BarColumn(),
             MofNCompleteColumn(),
             TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
             TimeElapsedColumn(),
             TimeRemainingColumn(),
-            transient=True,
-        ) as progress:
-            overall_task = progress.add_task(
+        )
+        batch_progress = Progress(*progress_columns, transient=True)
+        overall_progress = Progress(*progress_columns, transient=True)
+
+        with Live(Group(batch_progress, overall_progress), refresh_per_second=10):
+            overall_task = overall_progress.add_task(
                 "Total progress", total=total_players
             )
 
@@ -366,7 +374,7 @@ class EspnCoreRequests:
                 batch_size_actual = len(batch)
                 batch_num = i // batch_size + 1
 
-                batch_task = progress.add_task(
+                batch_task = batch_progress.add_task(
                     f"Batch {batch_num}/{total_batches}",
                     total=batch_size_actual,
                 )
@@ -398,10 +406,10 @@ class EspnCoreRequests:
                                     )
                                 failed_players.append(player)
 
-                            progress.advance(batch_task)
-                            progress.advance(overall_task)
+                            batch_progress.advance(batch_task)
+                            overall_progress.advance(overall_task)
                 finally:
-                    progress.remove_task(batch_task)
+                    batch_progress.remove_task(batch_task)
 
         hydration_elapsed = time.perf_counter() - hydration_start
 

--- a/espn_api_extractor/requests/core_requests.py
+++ b/espn_api_extractor/requests/core_requests.py
@@ -426,8 +426,8 @@ class EspnCoreRequests:
                 )
                 for entry in self.not_found_players:
                     self.logger.logging.warning(
-                        f"  [404 {entry['kind']}] ID={entry['id']}, "
-                        f"Name={entry['name']}, Team={entry['team']}"
+                        f"  [404 {entry['kind']}] {entry['id']}, "
+                        f"{entry['name']}, {entry['team']}"
                     )
 
             if failed_players:
@@ -444,8 +444,8 @@ class EspnCoreRequests:
                     )
                     player_team = getattr(player, "pro_team", None) or "Unknown"
                     self.logger.logging.warning(
-                        f"  Failed player {i + 1}: ID={player.id}, "
-                        f"Name={player_name}, Team={player_team}"
+                        f"  Failed player {i + 1}: {player.id}, "
+                        f"{player_name}, {player_team}"
                     )
                 if len(failed_players) > 10:
                     self.logger.logging.warning(

--- a/tests/controllers/test_player_controller.py
+++ b/tests/controllers/test_player_controller.py
@@ -65,7 +65,7 @@ def test_player_controller_no_updates_fully_hydrates(
     Since there are no hasura values returned, the controller implicitly does fully hydrate
     """
 
-    def _mock_get_player_data(self, player: Player) -> Dict[str, Any]:
+    def _mock_get_player_data(self, player_id, **kwargs) -> Dict[str, Any]:
         return carroll_athlete_fixture_data
 
     monkeypatch.setattr(

--- a/tests/requests/test_core_requests.py
+++ b/tests/requests/test_core_requests.py
@@ -230,6 +230,52 @@ class TestCoreRequests:
             "Failed to fetch player 12345 after 3 attempts"
         )
 
+    @mock.patch("requests.get")
+    def test_fetch_player_stats_retry_non_404(self, mock_get, core_requests):
+        """_fetch_player_stats should retry on non-404 errors and log via
+        _check_request_status (covers the non-404 branch added in the
+        aggregate-404-logging refactor)."""
+        mock_response1 = mock.MagicMock()
+        mock_response1.status_code = 500  # Retryable server error
+
+        mock_response2 = mock.MagicMock()
+        mock_response2.status_code = 200
+        mock_response2.json.return_value = {"stats": "data_after_retry"}
+
+        mock_get.side_effect = [mock_response1, mock_response2]
+
+        with mock.patch("time.sleep"):
+            result = core_requests._fetch_player_stats(player_id=12345)
+
+        assert mock_get.call_count == 2
+        assert result == {"stats": "data_after_retry"}
+        # _check_request_status logs "Internal server error" for 500.
+        core_requests.logger.logging.warning.assert_any_call("Internal server error")
+        # 404 store should remain empty for non-404 paths.
+        assert core_requests.not_found_players == []
+
+    @mock.patch("requests.get")
+    def test_fetch_player_stats_404(self, mock_get, core_requests):
+        """_fetch_player_stats records 404 hits silently to not_found_players."""
+        mock_response = mock.MagicMock()
+        mock_response.status_code = 404
+        mock_get.return_value = mock_response
+
+        player = Player(
+            data={"id": 12345, "fullName": "Test Player", "proTeamId": 0},
+            current_season=2025,
+        )
+
+        result = core_requests._fetch_player_stats(player_id=12345, player=player)
+
+        mock_get.assert_called_once()
+        assert result is None
+        assert len(core_requests.not_found_players) == 1
+        entry = core_requests.not_found_players[0]
+        assert entry["id"] == 12345
+        assert entry["kind"] == "stats"
+        core_requests.logger.logging.warning.assert_not_called()
+
     def test_hydrate_player_with_bio_without_id(self, core_requests):
         """Test _hydrate_player_with_bio with a player missing ID"""
         player = Player({"fullName": "Test Player"})  # No ID provided

--- a/tests/requests/test_core_requests.py
+++ b/tests/requests/test_core_requests.py
@@ -152,19 +152,29 @@ class TestCoreRequests:
         mock_response.status_code = 404
         mock_get.return_value = mock_response
 
-        # Test _get_player_data method
-        result = core_requests._get_player_data(player_id=12345)
+        # Build a Player so the 404 record can capture name/team
+        player = Player(
+            data={"id": 12345, "fullName": "Test Player", "proTeamId": 0},
+            current_season=2025,
+        )
 
-        # Verify request was made correctly
+        # Test _get_player_data method
+        result = core_requests._get_player_data(player_id=12345, player=player)
+
+        # Verify request was made exactly once (no retries on 404)
         mock_get.assert_called_once()
 
         # Verify result is None (indicating failure)
         assert result is None
 
-        # Verify log messages were called correctly
-        core_requests.logger.logging.warning.assert_any_call(
-            "Player ID 12345 not found (404) - skipping retries"
-        )
+        # 404s are now recorded silently to not_found_players instead of
+        # logging inline (which would interrupt the rich progress bar).
+        assert len(core_requests.not_found_players) == 1
+        entry = core_requests.not_found_players[0]
+        assert entry["id"] == 12345
+        assert entry["name"] == "Test Player"
+        assert entry["kind"] == "bio"
+        core_requests.logger.logging.warning.assert_not_called()
 
     @mock.patch("requests.get")
     def test_get_player_data_retry_non_404(self, mock_get, core_requests):

--- a/tests/requests/test_multi_threading.py
+++ b/tests/requests/test_multi_threading.py
@@ -72,8 +72,9 @@ class TestMultiThreading:
         assert result_player.bats == "Right"
         assert result_player.throws == "Right"
 
-        # Verify _get_player_data was called correctly
-        core_requests._get_player_data.assert_called_once_with(1)
+        # Verify _get_player_data was called correctly. _hydrate_player_with_bio
+        # passes the Player object so 404s can be recorded with name/team.
+        core_requests._get_player_data.assert_called_once_with(1, player=player)
 
     def test_hydrate_players_threading(self, mock_players, mock_logger, mock_response):
         """Test that hydrate_players uses multi-threading correctly"""
@@ -113,7 +114,7 @@ class TestMultiThreading:
         core_requests = EspnCoreRequests(sport="mlb", year=2025, max_workers=4)
 
         # Function to simulate API calls - returns None for player ID 5 (404 error)
-        def mock_get_player_data(player_id):
+        def mock_get_player_data(player_id, **kwargs):
             if player_id == 5:
                 return None
             return {
@@ -156,7 +157,7 @@ class TestMultiThreading:
         players = [Player({"id": i, "fullName": f"Player {i}"}) for i in range(1, 101)]
 
         # Function that simulates a slow API call (0.05 seconds per call)
-        def slow_get_player_data(player_id):
+        def slow_get_player_data(player_id, **kwargs):
             time.sleep(0.05)  # Simulate network delay
             return {
                 "id": str(player_id),


### PR DESCRIPTION
## Summary
- Suppress inline 404 logs during player hydration so the rich progress bar isn't interrupted; 404 hits land in a new `EspnCoreRequests.not_found_players` in-memory store and print as an aggregate report after the hydration cycle with player id, name, and pro team.
- Drop the per-player failure warning inside the `as_completed` loop (same progress-bar issue); end-of-run failed-player summary now includes team in addition to id and name.
- Bump CLI defaults: `--year` defaults to `2026` for both `player-extract` and `league-extract`; `--force-full-extraction` now defaults to `True` via `argparse.BooleanOptionalAction` (pass `--no-force-full-extraction` to disable).

## Test plan
- [x] `pytest -q --ignore=tests/requests/test_kona_playercard_extraction.py` — 138 passed, 1 skipped
- [x] `python -m espn_api_extractor player-extract --help` — confirms new defaults and `--no-force-full-extraction` toggle
- [ ] Run a live player-extract and confirm progress bar runs uninterrupted and the 404 summary prints at the end with name + team

🤖 Generated with [Claude Code](https://claude.com/claude-code)