### PR TITLE
chore: reword hydrate log from "Failed" to "Unable"

### DIFF
--- a/espn_api_extractor/controllers/player_controller.py
+++ b/espn_api_extractor/controllers/player_controller.py
@@ -161,7 +161,7 @@ class PlayerController:
                         f"Successfully hydrated {len(new_players)} new players"
                     )
                 except Exception as e:
-                    error_msg = f"Failed to hydrate new players: {str(e)}"
+                    error_msg = f"Unable to hydrate new players: {str(e)}"
                     self.logger.error(error_msg)
                     failures.append(error_msg)
 

--- a/espn_api_extractor/requests/core_requests.py
+++ b/espn_api_extractor/requests/core_requests.py
@@ -432,7 +432,7 @@ class EspnCoreRequests:
 
             if failed_players:
                 self.logger.logging.warning(
-                    f"Failed to hydrate {len(failed_players)} players"
+                    f"Unable to hydrate {len(failed_players)} players"
                 )
                 for i, player in enumerate(
                     failed_players[:10]

--- a/tests/controllers/test_player_controller.py
+++ b/tests/controllers/test_player_controller.py
@@ -148,7 +148,7 @@ def test_player_controller_handles_full_hydration_failure(monkeypatch):
     full_handler.execute.assert_awaited_once()
     assert result["players"] == []
     assert any(
-        "Failed to hydrate new players: hydrate boom" in msg
+        "Unable to hydrate new players: hydrate boom" in msg
         for msg in result["failures"]
     )
 


### PR DESCRIPTION
## Summary
- `"Failed to hydrate"` reads like an app failure in logs. Reword to `"Unable to hydrate"` to better signal upstream/data-source issues.

## Changes
- `core_requests.py` — warning log line
- `player_controller.py` — `error_msg`
- `test_player_controller.py` — assertion match updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)