### PR TITLE
Extract pitcher games-started limits and per-matchup counts

### DIFF
--- a/espn_api_extractor/base/base_settings.py
+++ b/espn_api_extractor/base/base_settings.py
@@ -1,3 +1,8 @@
+# ESPN stat id for pitcher games started; the games-started limits are
+# keyed on it. Defined locally to keep the base layer sport-agnostic.
+_GAMES_STARTED_STAT_ID = 33
+
+
 class BaseSettings(object):
     """Creates Settings object"""
 
@@ -7,6 +12,7 @@ class BaseSettings(object):
         draft_settings = data.get("draftSettings", {})
         scoring_settings = data.get("scoringSettings", {})
         acquisition_settings = data.get("acquisitionSettings", {})
+        roster_settings = data.get("rosterSettings", {})
 
         self.reg_season_count = schedule_settings.get("matchupPeriodCount", 0)
         self.matchup_periods = schedule_settings.get("matchupPeriods", {})
@@ -31,6 +37,41 @@ class BaseSettings(object):
         divisions = schedule_settings.get("divisions", [])
         for division in divisions:
             self.division_map[division.get("id", 0)] = division.get("name")
+
+        # Pitcher games-started limits (MLB H2H). ESPN splits these across two
+        # settings sections: statQualificationMinimum is the minimum games
+        # started needed to qualify for the pitching categories (miss it and
+        # they are forfeited); lineupSlotStatLimits is the per-scoring-period
+        # cap, scaled by matchupPeriodLength for the per-matchup cap. All None
+        # for leagues/sports without a games-started limit.
+        self.games_started_min = None
+        self.games_started_max_per_period = None
+        self.games_started_max_per_matchup = None
+
+        qualification = scoring_settings.get("statQualificationMinimum")
+        if (
+            isinstance(qualification, dict)
+            and qualification.get("statId") == _GAMES_STARTED_STAT_ID
+        ):
+            self.games_started_min = qualification.get("limitValue")
+
+        slot_limits = roster_settings.get("lineupSlotStatLimits")
+        if isinstance(slot_limits, dict):
+            for limit in slot_limits.values():
+                if (
+                    isinstance(limit, dict)
+                    and limit.get("statId") == _GAMES_STARTED_STAT_ID
+                ):
+                    self.games_started_max_per_period = limit.get("limitValue")
+                    break
+
+        period_length = schedule_settings.get("matchupPeriodLength")
+        if self.games_started_max_per_period is not None and isinstance(
+            period_length, (int, float)
+        ) and period_length:
+            self.games_started_max_per_matchup = round(
+                self.games_started_max_per_period * period_length
+            )
 
     def __repr__(self):
         return f"Settings({self.name})"

--- a/espn_api_extractor/baseball/constants.py
+++ b/espn_api_extractor/baseball/constants.py
@@ -1,5 +1,10 @@
 from typing import Dict
 
+# Stat id for pitcher games started. ESPN enforces a games-started limit on
+# pitchers and keys both the league-level limits and the per-matchup running
+# count on this id.
+GAMES_STARTED_STAT_ID = 33
+
 # Lineup slot ids (not position ids)
 LINEUP_SLOT_MAP: Dict[int, str] = {
     0: "C",

--- a/espn_api_extractor/baseball/matchup.py
+++ b/espn_api_extractor/baseball/matchup.py
@@ -1,9 +1,16 @@
+from .constants import GAMES_STARTED_STAT_ID
+
+
 class Matchup(object):
     """Creates Matchup instance"""
 
     def __init__(self, data):
         self.home_team_live_score = 0
         self.away_team_live_score = 0
+        self.home_games_started = None
+        self.away_games_started = None
+        self.home_games_started_limit_exceeded = None
+        self.away_games_started_limit_exceeded = None
         self._fetch_matchup_info(data)
 
     def __repr__(self):
@@ -34,7 +41,7 @@ class Matchup(object):
         # if stats are available
         if (
             "cumulativeScore" in data["home"].keys()
-            and data["home"]["cumulativeScore"]["scoreByStat"]
+            and data["home"]["cumulativeScore"].get("scoreByStat")
         ):
             self.home_team_live_score = (
                 data["home"]["cumulativeScore"]["wins"]
@@ -44,3 +51,42 @@ class Matchup(object):
                 data["away"]["cumulativeScore"]["wins"]
                 + data["away"]["cumulativeScore"]["ties"] / 2
             )
+
+        # Pitcher games started for each side, when ESPN reports it.
+        (
+            self.home_games_started,
+            self.home_games_started_limit_exceeded,
+        ) = self._fetch_games_started(data.get("home"))
+        (
+            self.away_games_started,
+            self.away_games_started_limit_exceeded,
+        ) = self._fetch_games_started(data.get("away"))
+
+    @staticmethod
+    def _fetch_games_started(side_data):
+        """Pitcher games started for one side of the matchup.
+
+        ESPN tracks the games-started count under cumulativeScore.statBySlot,
+        keyed by a virtual lineup slot; the entry whose statId is GS carries
+        the running count (the "Cur" in ESPN's box-score game-limits line)
+        and a flag for whether the cap was exceeded. Returns (None, None)
+        when no games-started entry is present.
+        """
+        if not isinstance(side_data, dict):
+            return (None, None)
+        cumulative_score = side_data.get("cumulativeScore")
+        if not isinstance(cumulative_score, dict):
+            return (None, None)
+        stat_by_slot = cumulative_score.get("statBySlot")
+        if not isinstance(stat_by_slot, dict):
+            return (None, None)
+        for slot_entry in stat_by_slot.values():
+            if (
+                isinstance(slot_entry, dict)
+                and slot_entry.get("statId") == GAMES_STARTED_STAT_ID
+            ):
+                return (
+                    slot_entry.get("value"),
+                    slot_entry.get("limitExceeded"),
+                )
+        return (None, None)

--- a/espn_api_extractor/handlers/league_handler.py
+++ b/espn_api_extractor/handlers/league_handler.py
@@ -15,6 +15,11 @@ EXCLUDED_SETTINGS_KEYS = {
 }
 ACQUISITION_SETTINGS_KEEP = {"acquisitionBudget"}
 
+# ESPN stat ID for pitcher games started. ESPN enforces a per-period
+# games-started cap on pitchers and tracks the running count under each
+# matchup's cumulativeScore.statBySlot.
+GAMES_STARTED_STAT_ID = 33
+
 
 class LeagueHandler:
     def __init__(
@@ -63,9 +68,70 @@ class LeagueHandler:
         settings = self._filter_acquisition_settings(settings)
         settings = self._filter_scoring_settings(settings)
 
+        games_started_limits = self._build_games_started_limits(settings)
+        if games_started_limits is not None:
+            settings = dict(settings)
+            settings["gamesStartedLimits"] = games_started_limits
+
         updated = dict(data)
         updated["settings"] = settings
         return updated
+
+    def _build_games_started_limits(self, settings: dict) -> Optional[dict]:
+        """Derive the league's pitcher games-started limits into one block.
+
+        ESPN splits this across two settings sections:
+          - scoringSettings.statQualificationMinimum -> the minimum games
+            started needed to qualify for the pitching categories; miss it
+            and those categories are forfeited (auto-loss).
+          - rosterSettings.lineupSlotStatLimits -> the per-scoring-period
+            cap. Multiply by scheduleSettings.matchupPeriodLength for the
+            per-matchup cap -- the "Max" in ESPN's box-score "Game Limits
+            (Cur/Max)" line.
+
+        Both are keyed on statId 33 (GS). Returns None when neither is
+        present (leagues without a games-started limit).
+        """
+        scoring = settings.get("scoringSettings")
+        roster = settings.get("rosterSettings")
+        schedule = settings.get("scheduleSettings")
+
+        min_value = None
+        if isinstance(scoring, dict):
+            qualification = scoring.get("statQualificationMinimum")
+            if (
+                isinstance(qualification, dict)
+                and qualification.get("statId") == GAMES_STARTED_STAT_ID
+            ):
+                min_value = qualification.get("limitValue")
+
+        max_per_period = None
+        if isinstance(roster, dict):
+            slot_limits = roster.get("lineupSlotStatLimits")
+            if isinstance(slot_limits, dict):
+                for limit in slot_limits.values():
+                    if (
+                        isinstance(limit, dict)
+                        and limit.get("statId") == GAMES_STARTED_STAT_ID
+                    ):
+                        max_per_period = limit.get("limitValue")
+                        break
+
+        if min_value is None and max_per_period is None:
+            return None
+
+        max_per_matchup = None
+        if max_per_period is not None and isinstance(schedule, dict):
+            period_length = schedule.get("matchupPeriodLength")
+            if isinstance(period_length, (int, float)) and period_length:
+                max_per_matchup = round(max_per_period * period_length)
+
+        return {
+            "statId": GAMES_STARTED_STAT_ID,
+            "min": min_value,
+            "maxPerScoringPeriod": max_per_period,
+            "maxPerMatchup": max_per_matchup,
+        }
 
     def _drop_settings_keys(self, settings: dict[str, Any]) -> dict[str, Any]:
         return {
@@ -216,6 +282,23 @@ class LeagueHandler:
         if category_results:
             simplified["categoryResults"] = category_results
 
+        # Preserve per-team pitcher games-started count + cap flag. ESPN
+        # enforces a games-started limit on pitchers; this is what the box
+        # score shows as "Game Limits (Cur/Max)". Lives in
+        # cumulativeScore.statBySlot, separate from scoreByStat. Omitted when
+        # ESPN returns no statBySlot (leagues without a games-started limit).
+        games_started = {}
+        if home_team_id is not None:
+            home_gs = self._format_games_started(home.get("cumulativeScore"))
+            if home_gs is not None:
+                games_started[home_team_id] = home_gs
+        if away_team_id is not None:
+            away_gs = self._format_games_started(away.get("cumulativeScore"))
+            if away_gs is not None:
+                games_started[away_team_id] = away_gs
+        if games_started:
+            simplified["gamesStarted"] = games_started
+
         return simplified
 
     def _format_record(self, cumulative_score: Optional[dict]) -> str:
@@ -264,6 +347,38 @@ class LeagueHandler:
                 "result": stat_dict.get("result"),
             }
         return results or None
+
+    def _format_games_started(
+        self, cumulative_score: Optional[dict]
+    ) -> Optional[dict]:
+        """Extract pitcher games-started count + cap flag from statBySlot.
+
+        ESPN tracks the games-started limit under cumulativeScore.statBySlot,
+        keyed by a virtual lineup slot. The entry whose statId is 33 (GS)
+        carries the running count (``value`` — the "Cur" in ESPN's box score),
+        whether the cap was exceeded, and the scoring period it was exceeded
+        on. The cap itself (the "Max") is league-level: see
+        settings.rosterSettings.lineupSlotStatLimits.
+
+        Returns None when no games-started entry is present (e.g. leagues
+        without a pitcher games-started limit), so callers can omit the field.
+        """
+        if not isinstance(cumulative_score, dict):
+            return None
+        stat_by_slot = cumulative_score.get("statBySlot")
+        if not isinstance(stat_by_slot, dict):
+            return None
+        for slot_entry in stat_by_slot.values():
+            if not isinstance(slot_entry, dict):
+                continue
+            if slot_entry.get("statId") != GAMES_STARTED_STAT_ID:
+                continue
+            return {
+                "value": slot_entry.get("value"),
+                "limitExceeded": slot_entry.get("limitExceeded"),
+                "exceededOnScoringPeriod": slot_entry.get("exceededOnScoringPeriod"),
+            }
+        return None
 
     def _normalize_winner(
         self,

--- a/tests/base/test_base_settings.py
+++ b/tests/base/test_base_settings.py
@@ -1,0 +1,52 @@
+from espn_api_extractor.base.base_settings import BaseSettings
+
+
+def test_games_started_limits_parsed():
+    """Min, per-period cap, and per-matchup cap are derived from settings."""
+    settings = BaseSettings(
+        {
+            "scoringSettings": {
+                "statQualificationMinimum": {"limitValue": 4, "statId": 33},
+            },
+            "rosterSettings": {
+                "lineupSlotStatLimits": {
+                    "22": {"limitValue": 1.4285714285714286, "statId": 33},
+                },
+            },
+            "scheduleSettings": {"matchupPeriodLength": 7},
+        }
+    )
+
+    assert settings.games_started_min == 4
+    assert settings.games_started_max_per_period == 1.4285714285714286
+    assert settings.games_started_max_per_matchup == 10
+
+
+def test_games_started_limits_absent():
+    """Leagues without a games-started limit leave the fields as None."""
+    settings = BaseSettings({})
+
+    assert settings.games_started_min is None
+    assert settings.games_started_max_per_period is None
+    assert settings.games_started_max_per_matchup is None
+
+
+def test_games_started_limits_ignore_other_stat_ids():
+    """Limits keyed on a non-GS stat id are not picked up."""
+    settings = BaseSettings(
+        {
+            "scoringSettings": {
+                "statQualificationMinimum": {"limitValue": 30, "statId": 81},
+            },
+            "rosterSettings": {
+                "lineupSlotStatLimits": {
+                    "7": {"limitValue": 9, "statId": 81},
+                },
+            },
+            "scheduleSettings": {"matchupPeriodLength": 7},
+        }
+    )
+
+    assert settings.games_started_min is None
+    assert settings.games_started_max_per_period is None
+    assert settings.games_started_max_per_matchup is None

--- a/tests/baseball/test_matchup.py
+++ b/tests/baseball/test_matchup.py
@@ -48,6 +48,23 @@ def test_matchup_games_started_absent():
     assert matchup.away_games_started is None
     assert matchup.home_games_started_limit_exceeded is None
     assert matchup.away_games_started_limit_exceeded is None
+    assert repr(matchup) == "Matchup(1, 2)"
+
+
+def test_fetch_games_started_handles_malformed_input():
+    """Malformed side shapes return (None, None) instead of raising."""
+    # Non-dict side data
+    assert Matchup._fetch_games_started(None) == (None, None)
+    # Non-dict cumulativeScore
+    assert Matchup._fetch_games_started({"cumulativeScore": "bad"}) == (None, None)
+    # Non-dict statBySlot
+    assert Matchup._fetch_games_started(
+        {"cumulativeScore": {"statBySlot": "bad"}}
+    ) == (None, None)
+    # statBySlot present but no games-started (statId 33) entry
+    assert Matchup._fetch_games_started(
+        {"cumulativeScore": {"statBySlot": {"7": {"statId": 81, "value": 9}}}}
+    ) == (None, None)
 
 
 def test_matchup_handles_cumulative_score_without_score_by_stat():
@@ -62,3 +79,34 @@ def test_matchup_handles_cumulative_score_without_score_by_stat():
 
     assert matchup.home_team_live_score == 0
     assert matchup.home_games_started == 3
+
+
+def test_matchup_live_score_from_cumulative_score():
+    """Live score is wins + ties/2 when scoreByStat is present."""
+    matchup = Matchup(
+        {
+            "home": {
+                "teamId": 1,
+                "totalPoints": 0,
+                "cumulativeScore": {
+                    "wins": 3,
+                    "ties": 2,
+                    "scoreByStat": {"20": {"score": 5, "result": "WIN"}},
+                },
+            },
+            "away": {
+                "teamId": 2,
+                "totalPoints": 0,
+                "cumulativeScore": {
+                    "wins": 1,
+                    "ties": 2,
+                    "scoreByStat": {"20": {"score": 3, "result": "LOSS"}},
+                },
+            },
+            "winner": "HOME",
+        }
+    )
+
+    assert matchup.home_team_live_score == 3 + 2 / 2
+    assert matchup.away_team_live_score == 1 + 2 / 2
+    assert repr(matchup) == "Matchup(1 4.0 - 2.0 2)"

--- a/tests/baseball/test_matchup.py
+++ b/tests/baseball/test_matchup.py
@@ -1,0 +1,64 @@
+from espn_api_extractor.baseball.matchup import Matchup
+
+
+def _side(team_id, games_started=None, limit_exceeded=False):
+    side = {"teamId": team_id, "totalPoints": 0}
+    if games_started is not None:
+        side["cumulativeScore"] = {
+            "wins": 0,
+            "ties": 0,
+            "statBySlot": {
+                "22": {
+                    "statId": 33,
+                    "value": games_started,
+                    "limitExceeded": limit_exceeded,
+                }
+            },
+        }
+    return side
+
+
+def test_matchup_parses_games_started():
+    """Pitcher games started + cap flag are read from cumulativeScore."""
+    matchup = Matchup(
+        {
+            "home": _side(1, games_started=5),
+            "away": _side(2, games_started=2, limit_exceeded=True),
+            "winner": "UNDECIDED",
+        }
+    )
+
+    assert matchup.home_games_started == 5
+    assert matchup.away_games_started == 2
+    assert matchup.home_games_started_limit_exceeded is False
+    assert matchup.away_games_started_limit_exceeded is True
+
+
+def test_matchup_games_started_absent():
+    """Matchups without statBySlot leave games-started fields as None."""
+    matchup = Matchup(
+        {
+            "home": _side(1),
+            "away": _side(2),
+            "winner": "UNDECIDED",
+        }
+    )
+
+    assert matchup.home_games_started is None
+    assert matchup.away_games_started is None
+    assert matchup.home_games_started_limit_exceeded is None
+    assert matchup.away_games_started_limit_exceeded is None
+
+
+def test_matchup_handles_cumulative_score_without_score_by_stat():
+    """cumulativeScore lacking scoreByStat (bye/early season) is not fatal."""
+    matchup = Matchup(
+        {
+            "home": _side(1, games_started=3),
+            "away": _side(2, games_started=1),
+            "winner": "UNDECIDED",
+        }
+    )
+
+    assert matchup.home_team_live_score == 0
+    assert matchup.home_games_started == 3

--- a/tests/handlers/test_league_handler.py
+++ b/tests/handlers/test_league_handler.py
@@ -153,13 +153,38 @@ def test_fetch_simplifies_schedule(league_response_fixture):
     else:
         expected_winner = None
 
-    assert simplified_matchup == {
+    expected = {
         "id": source_matchup["id"],
         "matchupPeriodId": source_matchup["matchupPeriodId"],
         "playoffTierType": source_matchup["playoffTierType"],
         "winner": expected_winner,
         "teams": expected_teams,
     }
+
+    # Pitcher games-started is preserved per team when ESPN returns statBySlot.
+    def _expected_games_started(team_record):
+        for slot_entry in team_record.get("statBySlot", {}).values():
+            if slot_entry.get("statId") == 33:
+                return {
+                    "value": slot_entry.get("value"),
+                    "limitExceeded": slot_entry.get("limitExceeded"),
+                    "exceededOnScoringPeriod": slot_entry.get(
+                        "exceededOnScoringPeriod"
+                    ),
+                }
+        return None
+
+    expected_games_started = {}
+    home_gs = _expected_games_started(home_record)
+    if home_gs is not None:
+        expected_games_started[home["teamId"]] = home_gs
+    away_gs = _expected_games_started(away_record)
+    if away_gs is not None:
+        expected_games_started[away["teamId"]] = away_gs
+    if expected_games_started:
+        expected["gamesStarted"] = expected_games_started
+
+    assert simplified_matchup == expected
 
 
 def test_fetch_marks_bye_week_when_single_team(league_response_fixture):
@@ -332,6 +357,163 @@ def test_fetch_preserves_category_results():
 
     plain_matchup = next(m for m in result["schedule"] if m["id"] == 11)
     assert "categoryResults" not in plain_matchup
+
+
+def test_fetch_preserves_games_started():
+    """Matchups carry per-team pitcher games-started count + cap flag."""
+    league = MagicMock()
+    league.espn_request.get_league.return_value = {
+        "id": 1,
+        "settings": None,
+        "status": {},
+        "teams": None,
+        "schedule": [
+            {
+                "id": 48,
+                "matchupPeriodId": 7,
+                "playoffTierType": "NONE",
+                "winner": "AWAY",
+                "home": {
+                    "teamId": 1,
+                    "cumulativeScore": {
+                        "wins": 0,
+                        "statBySlot": {
+                            "22": {
+                                "statId": 33,
+                                "value": 5,
+                                "limitExceeded": False,
+                                "exceededOnScoringPeriod": 0,
+                            }
+                        },
+                    },
+                },
+                "away": {
+                    "teamId": 8,
+                    "cumulativeScore": {
+                        "wins": 0,
+                        "statBySlot": {
+                            "22": {
+                                "statId": 33,
+                                "value": 2,
+                                "limitExceeded": False,
+                                "exceededOnScoringPeriod": 0,
+                            }
+                        },
+                    },
+                },
+            },
+            {
+                # No statBySlot -> no gamesStarted key
+                "id": 49,
+                "matchupPeriodId": 7,
+                "playoffTierType": "NONE",
+                "winner": "HOME",
+                "home": {"teamId": 2, "cumulativeScore": {"wins": 0}},
+                "away": {"teamId": 9, "cumulativeScore": {"wins": 0}},
+            },
+        ],
+    }
+
+    handler = LeagueHandler(year=2024, league_id=6789, league=league)
+    result = handler.fetch()
+
+    matchup = next(m for m in result["schedule"] if m["id"] == 48)
+    assert matchup["gamesStarted"] == {
+        1: {"value": 5, "limitExceeded": False, "exceededOnScoringPeriod": 0},
+        8: {"value": 2, "limitExceeded": False, "exceededOnScoringPeriod": 0},
+    }
+
+    plain = next(m for m in result["schedule"] if m["id"] == 49)
+    assert "gamesStarted" not in plain
+
+
+def test_build_games_started_limits():
+    """Min + max games-started limits are derived into one settings block."""
+    handler = LeagueHandler(year=2024, league_id=6789, league=MagicMock())
+
+    settings = {
+        "scoringSettings": {
+            "statQualificationMinimum": {"limitValue": 4, "statId": 33},
+        },
+        "rosterSettings": {
+            "lineupSlotStatLimits": {
+                "22": {"limitValue": 1.4285714285714286, "statId": 33},
+            },
+        },
+        "scheduleSettings": {"matchupPeriodLength": 7},
+    }
+
+    assert handler._build_games_started_limits(settings) == {
+        "statId": 33,
+        "min": 4,
+        "maxPerScoringPeriod": 1.4285714285714286,
+        "maxPerMatchup": 10,
+    }
+
+    # Wrong statId on either source is ignored; nothing usable -> None.
+    assert (
+        handler._build_games_started_limits(
+            {
+                "scoringSettings": {
+                    "statQualificationMinimum": {"limitValue": 4, "statId": 81}
+                },
+                "rosterSettings": {
+                    "lineupSlotStatLimits": {"7": {"limitValue": 9, "statId": 81}}
+                },
+            }
+        )
+        is None
+    )
+
+    # Min present but no cap / no period length -> maxPerMatchup is None.
+    assert handler._build_games_started_limits(
+        {"scoringSettings": {"statQualificationMinimum": {"limitValue": 4, "statId": 33}}}
+    ) == {
+        "statId": 33,
+        "min": 4,
+        "maxPerScoringPeriod": None,
+        "maxPerMatchup": None,
+    }
+
+
+def test_fetch_adds_games_started_limits(league_response_fixture):
+    """The derived gamesStartedLimits block is attached to settings."""
+    league = MagicMock()
+    league.espn_request.get_league.return_value = league_response_fixture
+
+    handler = LeagueHandler(year=2024, league_id=6789, league=league)
+    result = handler.fetch()
+
+    limits = result["settings"]["gamesStartedLimits"]
+    assert limits["statId"] == 33
+    assert limits["min"] == 4
+    assert limits["maxPerScoringPeriod"] == 1.4285714285714286
+
+
+def test_format_games_started_handles_malformed_input():
+    """Malformed statBySlot shapes are skipped, not raised on."""
+    handler = LeagueHandler(year=2024, league_id=6789, league=MagicMock())
+
+    # Non-dict cumulative_score -> None
+    assert handler._format_games_started(None) is None
+    assert handler._format_games_started("not a dict") is None
+
+    # Missing / non-dict statBySlot -> None
+    assert handler._format_games_started({"wins": 0}) is None
+    assert handler._format_games_started({"statBySlot": "nope"}) is None
+
+    # Non-dict slot entry skipped; no GS-statId entry -> None
+    assert (
+        handler._format_games_started(
+            {"statBySlot": {"22": "bad", "23": {"statId": 81, "value": 30}}}
+        )
+        is None
+    )
+
+    # Well-formed GS entry comes through
+    assert handler._format_games_started(
+        {"statBySlot": {"22": {"statId": 33, "value": 7, "limitExceeded": True}}}
+    ) == {"value": 7, "limitExceeded": True, "exceededOnScoringPeriod": None}
 
 
 def test_format_category_results_handles_malformed_input():


### PR DESCRIPTION
## Why

ESPN H2H baseball enforces a pitcher **games-started minimum** (miss it and the pitching categories are forfeited — auto-loss) and a per-scoring-period **maximum**. None of this was exported.

Symptom: a team with clearly better pitching rates gets marked `LOSS` on every pitching category. Looked like a `result` bug; it is correct — the team fell short of the games-started minimum. Without the games-started data the viz cannot show ESPN's `Game Limits (Cur/Max)` line or explain the result.

## What ESPN exposes (confirmed against `tests/fixtures/league_response.json`)

| Data | Location |
|---|---|
| Min (qualify or forfeit) | `scoringSettings.statQualificationMinimum` → `{limitValue: 4, statId: 33}` |
| Max (per scoring period) | `rosterSettings.lineupSlotStatLimits` → `{limitValue, statId: 33}` |
| Per-team per-matchup count | `cumulativeScore.statBySlot` → `{statId: 33, value, limitExceeded}` |

`statId 33` = GS. Per-matchup max = `maxPerScoringPeriod × matchupPeriodLength`.

## Changes

**Handler JSON export (`league_handler.py`)** — the R2/parquet source:
- `matchup.gamesStarted` — per team `{value, limitExceeded, exceededOnScoringPeriod}`. `statBySlot` was previously dropped by `_simplify_matchup`.
- `settings.gamesStartedLimits` — derived block `{statId, min, maxPerScoringPeriod, maxPerMatchup}`, flattening the two nested ESPN sources + the period-length math.

**Typed model:**
- `Matchup` — `home/away_games_started` and `home/away_games_started_limit_exceeded`.
- `BaseSettings` — `games_started_min`, `games_started_max_per_period`, `games_started_max_per_matchup`.

**Incidental fix:** `Matchup` read `cumulativeScore["scoreByStat"]` directly; ESPN sends `cumulativeScore` without that key for bye/early-season matchups, raising `KeyError`. Now read with `.get`.

## Notes

- The raw `rosterSettings` / `statQualificationMinimum` already shipped in the handler JSON; the downstream R2 parquet stage (separate repo) was selecting only `lineup_slot_counts` and must now also read `settings.gamesStartedLimits` + `matchup.gamesStarted`.
- ESPN exposes a real **minimum** (`statQualificationMinimum`) — confirms the auto-loss mechanism. `result`/scores untouched.

## Tests

157 passed, 1 skipped. Added `tests/baseball/test_matchup.py`, `tests/base/test_base_settings.py`, and games-started cases in `tests/handlers/test_league_handler.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)