### PR TITLE
feat: hydrate player news from ESPN Fantasy API

### DIFF
--- a/espn_api_extractor/baseball/player.py
+++ b/espn_api_extractor/baseball/player.py
@@ -75,6 +75,7 @@ class Player(object):
         self.bats: str | None = None
         self.throws: str | None = None
         self.active: bool | None = None
+        self.news: List[Dict[str, Any]] = []
 
         # Handle case where player info might be missing
         player = data.get("playerPoolEntry", {}).get("player") or data.get("player", {})
@@ -249,6 +250,7 @@ class Player(object):
             "throws",
             "active",
             "eligible_slots",
+            "news",
         ]
 
         for field in additional_fields:
@@ -393,6 +395,26 @@ class Player(object):
                 }
 
         self._reorder_stats()
+
+    def hydrate_news(self, data: dict) -> None:
+        """
+        Hydrates the player with news items from the ESPN Fantasy news API.
+
+        Args:
+            data: Response dict from ESPN Fantasy news endpoint
+        """
+        feed = data.get("news", {}).get("feed", [])
+        self.news = [
+            {
+                "id": item.get("id"),
+                "headline": item.get("headline", ""),
+                "description": item.get("description", ""),
+                "story": item.get("story", ""),
+                "published": item.get("published", ""),
+                "type": item.get("type", ""),
+            }
+            for item in feed
+        ]
 
     def _extract_draft_auction_value(
         self, transactions: List[Dict[str, Any]]

--- a/espn_api_extractor/models/player_model.py
+++ b/espn_api_extractor/models/player_model.py
@@ -87,6 +87,9 @@ class PlayerModel(BaseModel):
     # Also includes split_id, split_name, split_abbreviation, split_type, categories from season stats
     stats: Dict[str, Any] = Field(default_factory=dict)
 
+    # News items from ESPN Fantasy news API (Rotowire notes)
+    news: List[Dict[str, Any]] = Field(default_factory=list)
+
     @field_validator("eligible_slots", mode="before")
     @classmethod
     def parse_eligible_slots(cls, v):

--- a/espn_api_extractor/requests/constants.py
+++ b/espn_api_extractor/requests/constants.py
@@ -23,6 +23,11 @@ ESPN_CORE_SPORT_ENDPOINTS = {
     "nhl": ESPN_CORE_ENDPOINT_V2 + "/sports/hockey/leagues/nhl",
 }
 
+ESPN_PLAYER_NEWS_ENDPOINT = {
+    "mlb": NEWS_BASE_ENDPOINT + "flb/news/players",
+    "nfl": NEWS_BASE_ENDPOINT + "ffl/news/players",
+}
+
 # Statistics endpoints and constants
 # Type 2 = Regular Season, Type 1 = Spring Training
 STAT_SEASON_TYPE = 2

--- a/espn_api_extractor/requests/core_requests.py
+++ b/espn_api_extractor/requests/core_requests.py
@@ -377,9 +377,15 @@ class EspnCoreRequests:
             return hydrated_player, False
 
         if include_news and hydrated_player.id is not None:
-            news_data = self._fetch_player_news(hydrated_player.id)
-            if news_data is not None:
-                hydrated_player.hydrate_news(news_data)
+            try:
+                news_data = self._fetch_player_news(hydrated_player.id)
+                if news_data is not None:
+                    hydrated_player.hydrate_news(news_data)
+            except Exception as e:
+                with self.logger_lock:
+                    self.logger.logging.warning(
+                        f"Failed to hydrate news for player {hydrated_player.id}: {str(e)}"
+                    )
 
         return hydrated_player, bio_success
 

--- a/espn_api_extractor/requests/core_requests.py
+++ b/espn_api_extractor/requests/core_requests.py
@@ -21,7 +21,12 @@ from typing_extensions import Any, Dict, List, Optional, Tuple
 from espn_api_extractor.baseball.player import Player
 from espn_api_extractor.utils.logger import Logger
 
-from .constants import ESPN_CORE_SPORT_ENDPOINTS, STAT_CATEGORY, STAT_SEASON_TYPE
+from .constants import (
+    ESPN_CORE_SPORT_ENDPOINTS,
+    ESPN_PLAYER_NEWS_ENDPOINT,
+    STAT_CATEGORY,
+    STAT_SEASON_TYPE,
+)
 
 
 class EspnCoreRequests:
@@ -30,6 +35,7 @@ class EspnCoreRequests:
             assert sport in ["nfl", "mlb"]
             self.sport = sport
             self.sport_endpoint = ESPN_CORE_SPORT_ENDPOINTS[sport]
+            self.news_endpoint = ESPN_PLAYER_NEWS_ENDPOINT.get(sport, "")
             self.year = year
         except AssertionError:
             print("Invalid sport")
@@ -258,6 +264,59 @@ class EspnCoreRequests:
             )
         return None
 
+    def _fetch_player_news(
+        self,
+        player_id: int,
+        limit: int = 5,
+        max_retries: int = 2,
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Fetch player news from ESPN Fantasy API.
+        Returns response dict on success, None on failure or missing news endpoint.
+        404 responses return None without recording to not_found_players (no news is normal).
+        """
+        if not self.news_endpoint:
+            return None
+
+        params = {"playerId": player_id, "limit": limit}
+        retries = 0
+        backoff_time = 1
+
+        while retries < max_retries:
+            try:
+                r = requests.get(
+                    self.news_endpoint,
+                    params=params,
+                    headers=self.session.headers,
+                    cookies=self.session.cookies,
+                    timeout=10,
+                )
+
+                if r.status_code == 200:
+                    return r.json()
+
+                # 404 means no news for this player — not an error
+                if r.status_code == 404:
+                    return None
+
+                self._check_request_status(
+                    r.status_code, extend=self.news_endpoint, params=params
+                )
+
+            except Exception as e:
+                with self.logger_lock:
+                    self.logger.logging.warning(
+                        f"Exception fetching news for player {player_id} "
+                        f"(attempt {retries + 1}/{max_retries}): {str(e)}"
+                    )
+
+            retries += 1
+            if retries < max_retries:
+                time.sleep(backoff_time)
+                backoff_time *= 2
+
+        return None
+
     def _record_not_found(
         self, player_id: int, player: Optional[Player], kind: str
     ) -> None:
@@ -303,25 +362,33 @@ class EspnCoreRequests:
             return player, False
 
     def _hydrate_player_worker(
-        self, player: Player, include_stats: bool = False
+        self, player: Player, include_stats: bool = False, include_news: bool = True
     ) -> Tuple[Player, bool]:
         """
         Worker function for ThreadPoolExecutor that handles the hydration logic.
-        Calls appropriate hydration methods based on include_stats parameter.
-        Stats hydration is no longer performed; include_stats is retained for compatibility.
+        Fetches bio data and optionally player news per player.
+        include_stats is retained for compatibility but has no effect.
         """
         if include_stats:
             pass
-        # First, hydrate with biographical data
         hydrated_player, bio_success = self._hydrate_player_with_bio(player)
 
         if not bio_success:
             return hydrated_player, False
 
+        if include_news and hydrated_player.id is not None:
+            news_data = self._fetch_player_news(hydrated_player.id)
+            if news_data is not None:
+                hydrated_player.hydrate_news(news_data)
+
         return hydrated_player, bio_success
 
     def hydrate_players(
-        self, players: list[Player], batch_size: int = 100, include_stats: bool = False
+        self,
+        players: list[Player],
+        batch_size: int = 100,
+        include_stats: bool = False,
+        include_news: bool = True,
     ) -> Tuple[List[Player], List[Player]]:
         """
         Hydrate a list of players with additional data using multi-threading.
@@ -332,6 +399,7 @@ class EspnCoreRequests:
             batch_size: Number of players to process in each batch (to manage progress bar)
             include_stats: Ignored. Kona playercard provides stats, so Core API
                 hydration only fetches biographical data.
+            include_news: Whether to fetch player news alongside bio data.
         """
         hydrated_players: List[Player] = []
         failed_players: List[Player] = []
@@ -382,7 +450,10 @@ class EspnCoreRequests:
                     with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
                         futures_to_players = {
                             executor.submit(
-                                self._hydrate_player_worker, player, include_stats
+                                self._hydrate_player_worker,
+                                player,
+                                include_stats,
+                                include_news,
                             ): player
                             for player in batch
                         }

--- a/tests/requests/test_core_requests.py
+++ b/tests/requests/test_core_requests.py
@@ -474,6 +474,23 @@ class TestCoreRequests:
         assert len(result_player.news) == 1
         assert result_player.news[0]["headline"] == "Test news"
 
+    def test_hydrate_player_worker_news_exception_still_succeeds(self, core_requests):
+        """News hydration failure does not fail the worker — bio success is preserved."""
+        player = Player({"id": 123, "fullName": "Test Player"})
+
+        core_requests._hydrate_player_with_bio = mock.MagicMock(
+            return_value=(player, True)
+        )
+        core_requests._fetch_player_news = mock.MagicMock(
+            side_effect=ValueError("bad JSON")
+        )
+
+        result_player, success = core_requests._hydrate_player_worker(player)
+
+        assert success is True
+        assert result_player.news == []
+        core_requests.logger.logging.warning.assert_called_once()
+
     def test_hydrate_player_worker_include_news_false(self, core_requests):
         """Worker skips news fetch when include_news=False."""
         player = Player({"id": 123, "fullName": "Test Player"})

--- a/tests/requests/test_core_requests.py
+++ b/tests/requests/test_core_requests.py
@@ -423,6 +423,41 @@ class TestCoreRequests:
         assert result is None
         mock_get.assert_not_called()
 
+    @mock.patch("requests.get")
+    def test_fetch_player_news_retry_non_404(self, mock_get, core_requests):
+        """Non-404 error is logged via _check_request_status then retried."""
+        mock_bad = mock.MagicMock()
+        mock_bad.status_code = 500
+
+        news_payload = {"news": {"feed": []}}
+        mock_ok = mock.MagicMock()
+        mock_ok.status_code = 200
+        mock_ok.json.return_value = news_payload
+
+        mock_get.side_effect = [mock_bad, mock_ok]
+
+        with mock.patch("time.sleep"):
+            result = core_requests._fetch_player_news(player_id=39832)
+
+        assert result == news_payload
+        assert mock_get.call_count == 2
+        core_requests.logger.logging.warning.assert_any_call("Internal server error")
+
+    @mock.patch("requests.get")
+    def test_fetch_player_news_exception_retries_then_none(self, mock_get, core_requests):
+        """Exception during request retries up to max_retries then returns None."""
+        mock_get.side_effect = [
+            ConnectionError("timeout"),
+            ConnectionError("timeout"),
+        ]
+
+        with mock.patch("time.sleep"):
+            result = core_requests._fetch_player_news(player_id=39832, max_retries=2)
+
+        assert result is None
+        assert mock_get.call_count == 2
+        assert core_requests.logger.logging.warning.call_count >= 1
+
     def test_hydrate_player_worker_applies_news(self, core_requests):
         """Worker calls hydrate_news on player when news data is returned."""
         player = Player({"id": 123, "fullName": "Test Player"})

--- a/tests/requests/test_core_requests.py
+++ b/tests/requests/test_core_requests.py
@@ -312,25 +312,21 @@ class TestCoreRequests:
 
     def test_hydrate_player_worker_bio_only(self, core_requests):
         """Test _hydrate_player_worker with include_stats=False (bio only)"""
-        # Create a player with valid ID
         player = Player({"id": 123, "fullName": "Test Player"})
 
-        # Mock _hydrate_player_with_bio to return success
         core_requests._hydrate_player_with_bio = mock.MagicMock(
             return_value=(player, True)
         )
+        core_requests._fetch_player_news = mock.MagicMock(return_value=None)
 
-        # Call _hydrate_player_worker with include_stats=False
         result_player, success = core_requests._hydrate_player_worker(
             player, include_stats=False
         )
 
-        # Verify results
         assert result_player is player
         assert success is True
-
-        # Verify _hydrate_player_with_bio was called
         core_requests._hydrate_player_with_bio.assert_called_once_with(player)
+        core_requests._fetch_player_news.assert_called_once_with(123)
 
     def test_hydrate_player_worker_ignores_include_stats(self, core_requests):
         """Test _hydrate_player_worker ignores include_stats flag"""
@@ -342,6 +338,7 @@ class TestCoreRequests:
         core_requests._hydrate_player_with_bio = mock.MagicMock(
             return_value=(hydrated_player, True)
         )
+        core_requests._fetch_player_news = mock.MagicMock(return_value=None)
 
         result_player, success = core_requests._hydrate_player_worker(
             player, include_stats=True
@@ -353,90 +350,182 @@ class TestCoreRequests:
 
     def test_hydrate_player_worker_bio_fails(self, core_requests):
         """Test _hydrate_player_worker when bio hydration fails"""
-        # Create a player with valid ID
         player = Player({"id": 123, "fullName": "Test Player"})
 
-        # Mock _hydrate_player_with_bio to return failure
         core_requests._hydrate_player_with_bio = mock.MagicMock(
             return_value=(player, False)
         )
-        # Call _hydrate_player_worker with include_stats=True
+        core_requests._fetch_player_news = mock.MagicMock(return_value=None)
+
         result_player, success = core_requests._hydrate_player_worker(
             player, include_stats=True
         )
 
-        # Verify results
         assert result_player is player
         assert success is False
-
-        # Verify _hydrate_player_with_bio was called
         core_requests._hydrate_player_with_bio.assert_called_once_with(player)
+        # News should not be fetched when bio fails
+        core_requests._fetch_player_news.assert_not_called()
+
+    @mock.patch("requests.get")
+    def test_fetch_player_news_success(self, mock_get, core_requests):
+        """_fetch_player_news returns parsed JSON on 200."""
+        news_payload = {
+            "news": {
+                "feed": [
+                    {
+                        "id": 100,
+                        "type": "Rotowire",
+                        "headline": "Player homers",
+                        "description": "Went deep.",
+                        "story": "Hit a solo shot.",
+                        "published": "2026-06-11T04:00:00Z",
+                    }
+                ]
+            }
+        }
+        mock_response = mock.MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = news_payload
+        mock_get.return_value = mock_response
+
+        result = core_requests._fetch_player_news(player_id=39832)
+
+        assert result == news_payload
+        mock_get.assert_called_once_with(
+            core_requests.news_endpoint,
+            params={"playerId": 39832, "limit": 5},
+            headers=core_requests.session.headers,
+            cookies=core_requests.session.cookies,
+            timeout=10,
+        )
+
+    @mock.patch("requests.get")
+    def test_fetch_player_news_404_returns_none(self, mock_get, core_requests):
+        """404 from news endpoint returns None without recording to not_found_players."""
+        mock_response = mock.MagicMock()
+        mock_response.status_code = 404
+        mock_get.return_value = mock_response
+
+        result = core_requests._fetch_player_news(player_id=99999)
+
+        assert result is None
+        assert core_requests.not_found_players == []
+        core_requests.logger.logging.warning.assert_not_called()
+
+    @mock.patch("requests.get")
+    def test_fetch_player_news_no_endpoint(self, mock_get, core_requests):
+        """_fetch_player_news returns None immediately when news_endpoint is empty."""
+        core_requests.news_endpoint = ""
+
+        result = core_requests._fetch_player_news(player_id=39832)
+
+        assert result is None
+        mock_get.assert_not_called()
+
+    def test_hydrate_player_worker_applies_news(self, core_requests):
+        """Worker calls hydrate_news on player when news data is returned."""
+        player = Player({"id": 123, "fullName": "Test Player"})
+        news_payload = {"news": {"feed": [{"id": 1, "headline": "Test news", "description": "", "story": "", "published": "", "type": "Rotowire"}]}}
+
+        core_requests._hydrate_player_with_bio = mock.MagicMock(
+            return_value=(player, True)
+        )
+        core_requests._fetch_player_news = mock.MagicMock(return_value=news_payload)
+
+        result_player, success = core_requests._hydrate_player_worker(player)
+
+        assert success is True
+        assert len(result_player.news) == 1
+        assert result_player.news[0]["headline"] == "Test news"
+
+    def test_hydrate_player_worker_include_news_false(self, core_requests):
+        """Worker skips news fetch when include_news=False."""
+        player = Player({"id": 123, "fullName": "Test Player"})
+
+        core_requests._hydrate_player_with_bio = mock.MagicMock(
+            return_value=(player, True)
+        )
+        core_requests._fetch_player_news = mock.MagicMock(return_value=None)
+
+        result_player, success = core_requests._hydrate_player_worker(
+            player, include_news=False
+        )
+
+        assert success is True
+        core_requests._fetch_player_news.assert_not_called()
 
     def test_hydrate_players_with_include_stats_false(self, core_requests):
         """Test hydrate_players method with include_stats=False"""
-        # Create test players
         players = [
             Player({"id": 1, "fullName": "Player 1"}),
             Player({"id": 2, "fullName": "Player 2"}),
         ]
 
-        # Mock _hydrate_player_worker to return success for both players
-        def mock_worker(player, include_stats):
-            assert include_stats is False  # Verify the parameter is passed correctly
+        def mock_worker(player, include_stats, include_news):
+            assert include_stats is False
             return player, True
 
         core_requests._hydrate_player_worker = mock.MagicMock(side_effect=mock_worker)
 
-        # Call hydrate_players with include_stats=False (default)
         hydrated_players, failed_players = core_requests.hydrate_players(
             players, batch_size=5
         )
 
-        # Verify results
         assert len(hydrated_players) == 2
         assert len(failed_players) == 0
-
-        # Verify _hydrate_player_worker was called correctly for each player
         assert core_requests._hydrate_player_worker.call_count == 2
 
-        # Verify each call had include_stats=False
         for call in core_requests._hydrate_player_worker.call_args_list:
             args, kwargs = call
-            player_arg, include_stats_arg = args
+            _, include_stats_arg, include_news_arg = args
             assert include_stats_arg is False
+            assert include_news_arg is True  # default
 
     def test_hydrate_players_with_include_stats_true(self, core_requests):
         """Test hydrate_players method with include_stats=True"""
-        # Create test players
         players = [
             Player({"id": 1, "fullName": "Player 1"}),
             Player({"id": 2, "fullName": "Player 2"}),
         ]
 
-        # Mock _hydrate_player_worker to return success for both players
-        def mock_worker(player, include_stats):
-            assert include_stats is True  # Verify the parameter is passed correctly
+        def mock_worker(player, include_stats, include_news):
+            assert include_stats is True
             return player, True
 
         core_requests._hydrate_player_worker = mock.MagicMock(side_effect=mock_worker)
 
-        # Call hydrate_players with include_stats=True
         hydrated_players, failed_players = core_requests.hydrate_players(
             players, batch_size=5, include_stats=True
         )
 
-        # Verify results
         assert len(hydrated_players) == 2
         assert len(failed_players) == 0
-
-        # Verify _hydrate_player_worker was called correctly for each player
         assert core_requests._hydrate_player_worker.call_count == 2
 
-        # Verify each call had include_stats=True
         for call in core_requests._hydrate_player_worker.call_args_list:
             args, kwargs = call
-            player_arg, include_stats_arg = args
+            _, include_stats_arg, _ = args
             assert include_stats_arg is True
+
+    def test_hydrate_players_include_news_false(self, core_requests):
+        """Test hydrate_players passes include_news=False to worker."""
+        players = [Player({"id": 1, "fullName": "Player 1"})]
+
+        def mock_worker(player, include_stats, include_news):
+            assert include_news is False
+            return player, True
+
+        core_requests._hydrate_player_worker = mock.MagicMock(side_effect=mock_worker)
+
+        hydrated_players, failed_players = core_requests.hydrate_players(
+            players, batch_size=5, include_news=False
+        )
+
+        assert len(hydrated_players) == 1
+        for call in core_requests._hydrate_player_worker.call_args_list:
+            args, _ = call
+            assert args[2] is False  # include_news
 
 
 class TestCoreRequestsIntegration:


### PR DESCRIPTION
## Summary

- **New endpoint:** `https://site.api.espn.com/apis/fantasy/v3/games/flb/news/players?playerId={id}&limit=5` returns Rotowire fantasy notes scoped to a single player
- **Zero extra passes:** news is fetched inside the existing `_hydrate_player_worker` ThreadPoolExecutor alongside bio, reusing the same per-player thread
- **Opt-out available:** `hydrate_players(..., include_news=False)` and `_hydrate_player_worker(..., include_news=False)` skip the fetch entirely

## Changed files

| File | Change |
|------|--------|
| `requests/constants.py` | Add `ESPN_PLAYER_NEWS_ENDPOINT` dict mapping sport → news URL |
| `requests/core_requests.py` | `self.news_endpoint` on init; `_fetch_player_news()` with retry/404 handling; `_hydrate_player_worker` + `hydrate_players` gain `include_news=True` param |
| `baseball/player.py` | `self.news: List[Dict]` field; `hydrate_news(data)` method |
| `models/player_model.py` | `news: List[Dict[str, Any]]` field |
| `tests/requests/test_core_requests.py` | 5 new tests; 3 existing worker tests updated to mock `_fetch_player_news` |

## Data shape

Each `player.news` item:
```python
{
    "id": 100836210,
    "headline": "Ohtani took a no-decision Wednesday...",
    "description": "...",
    "story": "Full Rotowire analysis paragraph...",
    "published": "2026-06-11T04:34:09Z",
    "type": "Rotowire",
}
```

## Downstream notes for consumers

- `player.news` is always present (empty list `[]` when no news or `include_news=False`)
- `PlayerModel.news` is a `List[Dict[str, Any]]` — safe to serialize to JSON/GraphQL as-is
- 404 from the news endpoint is treated as "no news" — not logged, not counted as a failure
- `limit=5` hardcoded; can be exposed as a param if callers need more history

## Test plan

- [x] `_fetch_player_news` success, 404, empty endpoint
- [x] Worker applies news to player when data returned
- [x] Worker skips news when `include_news=False`
- [x] `hydrate_players` passes `include_news` through to worker
- [x] Bio failure short-circuits before news fetch
- [x] Full suite: 165 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)